### PR TITLE
Fix/manifests

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -26,11 +26,6 @@ COPY . .
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
-ARG NEXT_PUBLIC_BASE_URL
-ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
-
-ARG NEXT_PUBLIC_WS_URL
-ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 
 
 RUN \

--- a/client/manifests/service.yaml
+++ b/client/manifests/service.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: client
-        image: amaglione/client-test:latest
+        image: amaglione/client:latest
         ports:
         - containerPort: 3000
         env:

--- a/client/manifests/service.yaml
+++ b/client/manifests/service.yaml
@@ -27,6 +27,12 @@ spec:
     spec:
       containers:
       - name: client
-        image: amaglione/client:latest
+        image: amaglione/client-test:latest
         ports:
         - containerPort: 3000
+        env:
+        - name: BASE_URL
+          value: "server"
+        - name: WS_URL
+        # Replace value for WS_URL with the LoadBalancer IP of the server service
+          value: "localhost:8081"

--- a/client/pages/api/addOption.js
+++ b/client/pages/api/addOption.js
@@ -1,4 +1,4 @@
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = `http://${process.env.BASE_URL}`;
 
 export default async function handler(req, res) {
     const teamId = req.query.teamId;

--- a/client/pages/api/deleteOption.js
+++ b/client/pages/api/deleteOption.js
@@ -1,4 +1,4 @@
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = `http://${process.env.BASE_URL}`;
 
 export default async function handler(req, res) {
     const teamId = req.query.teamId;

--- a/client/pages/api/getWsUrl.js
+++ b/client/pages/api/getWsUrl.js
@@ -1,0 +1,3 @@
+export default async function handler(req, res) {
+    res.status(200).json({ wsUrl: process.env.WS_URL });
+}

--- a/client/pages/api/status.js
+++ b/client/pages/api/status.js
@@ -1,4 +1,4 @@
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = `http://${process.env.BASE_URL}`;
 
 export default async function handler(req, res) {
     try {

--- a/client/pages/api/vote.js
+++ b/client/pages/api/vote.js
@@ -1,4 +1,4 @@
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const baseUrl = `http://${process.env.BASE_URL}`;
 
 export default async function handler(req, res) {
     const teamId = req.query.teamId;

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -4,8 +4,6 @@ import { getInitialStatus } from '@/services';
 // import { baseUrl } from '@/constants';
 
 export default function Home() {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
-  console.log("La url es", `ws://${process.env.NEXT_PUBLIC_WS_URL}/status`)
   const [options, setOptions] = useState([]);
 
 
@@ -13,6 +11,12 @@ export default function Home() {
     const options = await getInitialStatus();
     console.log(options)
     options && setOptions(options)
+  }
+
+  const getWsUrl = async () => {
+    const response = await fetch('/api/getWsUrl');
+    const { wsUrl } = await response.json();
+    return wsUrl;
   }
 
   const addOption = async (option) => {
@@ -34,10 +38,11 @@ export default function Home() {
     });
   }
 
-  useEffect(() => {
+  useEffect(async () => {
     getStatus()
 
-    const socket = new WebSocket(`ws://${process.env.NEXT_PUBLIC_WS_URL}/status`);
+    const wsUrl = await getWsUrl();
+    const socket = new WebSocket(`ws://${wsUrl}/status`);
 
     socket.onmessage = (event) => {
       const { team, operation } = JSON.parse(event.data);

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,46 @@
+# Sistemas Distribuidos
+## Trabajo Práctico Integrador
+
+### Integrantes
+- Nahuel Arrieta
+- Andrés Maglione
+
+## Descripción
+La siguiente aplicación permite realizar votaciones multiusuario en tiempo real. Los clientes pueden añadir nuevas opciones, votar por las opciones existentes y ver los resultados en tiempo real.
+
+### Arquitectura
+La aplicación utiliza una arquitectura cliente-servidor con las siguientes particularidades:
+- El cliente obtiene los datos iniciales a través de peticiones HTTP. También se utiliza HTTP para votar por una opción, agregar una opción nueva o eliminar una opción.
+- Cada cliente, a su vez, mantiene una conexión WebSocket con el servidor para recibir actualizaciones en tiempo real.
+- Cuando un cliente realiza una acción, el servidor escribe los cambios en un bus de eventos pub/sub utilizando Redis.
+- Cada instancia del servidor se suscribe al bus de eventos para recibir las actualizaciones. Las notificaciones son enviadas a los clientes que están conectados a través de WebSocket.
+
+### Servidor
+Fue programado utilizando Go. En el directorio `/server` se puede encontrar el código para el servidor junto con su Dockerfile y su manifiesto de Kubernetes.
+
+### Cliente
+Fue programado utilizando Next.js. En el directorio `/client` se puede encontrar el código para el cliente junto con su Dockerfile y su manifiesto de Kubernetes.
+
+### Instalación
+Actualmente, la configuración debe realizarse de la siguiente manera:
+1. Instalar Redis usando Helm:
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install redis bitnami/redis
+```
+2. Desplegar el back-end desde el directorio `/server`:
+```bash
+kubectl apply -f manifests/service.yaml
+```
+
+3. Desplegar el front-end desde el directorio `/client`. Antess de ejecutar el comando, se debe modificar la variable de entorno `WS_URL` por la IP ública del servidor:
+```bash
+kubectl apply -f manifests/service.yaml
+```
+
+Luego, el front-end debería estar accesible en la IP que le asigne el LoadBalancer.
+
+### Información extra
+La aplicación se encuentra desplegada con una IP pública para la VPN de la cátedra. La misma está accesible (al momento de la creación de este readme) en la siguiente dirección: [http://10.230.110.13](http://10.230.110.13).
+
+Además de los despliegues para Kubernetes, en la raíz del proyecto se puede encontrar un archivo `compose.yml` que permite levantar la aplicación usando Docker Compose.

--- a/server/main.go
+++ b/server/main.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"log"
-	"os"
 	"server/server"
 )
 
 func main() {
 	// Initialize an http server
-	server, err := server.New(os.Getenv("PORT"))
+	server, err := server.New("8080")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/server/manifests/service.yaml
+++ b/server/manifests/service.yaml
@@ -33,9 +33,9 @@ spec:
         - containerPort: 8080
         env:
         - name: REDIS_ADDR
-          value: "10.43.34.4"
+          value: "10.102.61.76"
         - name: REDIS_PASSWORD
-          value: "yMaMgviNcX"
+          value: "kN5zu183AA"
         - name: PORT
           value: "8080"
 

--- a/server/manifests/service.yaml
+++ b/server/manifests/service.yaml
@@ -33,9 +33,9 @@ spec:
         - containerPort: 8080
         env:
         - name: REDIS_ADDR
-          value: "10.102.61.76"
+          value: "redis-master"
         - name: REDIS_PASSWORD
-          value: "kN5zu183AA"
-        - name: PORT
-          value: "8080"
-
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password


### PR DESCRIPTION
El chapa me enseño como funcionan las variables de entorno en Next.

Todo lo que está en API puede obtener variables de entorno de toda la vida. El `index.js` ahora usa una api route para obtener la ip de websocket, que es lo que mas probelmas causaba

Cambie el manifiesto del server:
- La ip de redis la obtiene usando DNS de kubernetes
- La contraseña la saca de un secret

Add readme.md